### PR TITLE
Delete address associated with "non-complete" orders

### DIFF
--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -19,12 +19,16 @@ class User::AddressesController < User::BaseController
   def destroy
     address = Address.find(params[:id])
     if address.user_id == current_user.id
-      if address.no_orders?
-        Address.destroy(address.id)
+      if address.no_completed_orders?
+        nickname = address.nickname
+        address.user.update(primary_address_id: nil)
+        address.orders.clear
+        address.destroy
+        flash[:success] = "#{nickname.titlecase} address has been deleted"
         redirect_to profile_path
         return
       else
-        flash[:danger] = "Cannot delete an address that was used for an order"
+        flash[:danger] = "Cannot delete an address that was used for packaged/shipped order(s)"
         redirect_back fallback_location: profile_path
       end
     else

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -21,9 +21,7 @@ class User::AddressesController < User::BaseController
     if address.user_id == current_user.id
       if address.no_completed_orders?
         nickname = address.nickname
-        address.user.update(primary_address_id: nil)
-        address.orders.clear
-        address.destroy
+        address.delete_addr_and_associations
         flash[:success] = "#{nickname.titlecase} address has been deleted"
         redirect_to profile_path
         return

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -8,7 +8,7 @@ class Address < ApplicationRecord
                         :state,
                         :zip
 
-  def no_orders?
-    Order.where(address_id: id).count == 0
+  def no_completed_orders?
+    Order.where(address_id: id).where(status: ["shipped", "packaged"]).count == 0
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -9,7 +9,7 @@ class Address < ApplicationRecord
                         :zip
 
   def no_completed_orders?
-    Order.where(address_id: id).where(status: ["shipped", "packaged"]).count == 0
+    orders.where(status: ["shipped", "packaged"]).count == 0
   end
 
   def delete_addr_and_associations

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -11,4 +11,10 @@ class Address < ApplicationRecord
   def no_completed_orders?
     Order.where(address_id: id).where(status: ["shipped", "packaged"]).count == 0
   end
+
+  def delete_addr_and_associations
+    user.update(primary_address_id: nil)
+    orders.clear
+    destroy
+  end
 end

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "profile page" do
       end
 
       expect(current_path).to eq(profile_path)
-      expect(page).to have_content("Cannot delete an address that was used for a packaged order")
+      expect(page).to have_content("Cannot delete an address that was used for packaged/shipped order(s)")
       expect(@address.reload.id).to eq(original_addr_id)
     end
 
@@ -128,7 +128,7 @@ RSpec.describe "profile page" do
       end
 
       expect(current_path).to eq(profile_path)
-      expect(page).to have_content("Cannot delete an address that was used for a shipped order")
+      expect(page).to have_content("Cannot delete an address that was used for packaged/shipped order(s)")
       expect(@address.reload.id).to eq(original_addr_id)
     end
 

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe "profile page" do
     it "has buttons to delete my addresses" do
       visit profile_path
 
+      original_street = @another_address.street
+      original_nickname = @another_address.nickname
+
       within("#address-#{@address.id}") do
         expect(page).to have_button("Delete Address")
       end
@@ -46,7 +49,8 @@ RSpec.describe "profile page" do
       end
 
       expect(current_path).to eq(profile_path)
-      expect(page).to_not have_content(@another_address.street)
+      expect(page).to_not have_content(original_street)
+      expect(page).to have_content("#{original_nickname.titlecase} address has been deleted")
     end
 
     it "I can't delete someone else's address" do
@@ -64,8 +68,42 @@ RSpec.describe "profile page" do
       expect(@address.reload.id).to eq(original_addr_id)
     end
 
-    it "I can't delete an address with associated orders" do
-      order = create(:order, address: @address)
+    it "I can delete an address with associated pending orders" do
+      order = create(:order, address: @address) # pending order
+      original_addr_id = @address.id
+      original_addr_nickname = @address.nickname
+      original_addr_street = @address.street
+
+      visit profile_path
+
+      within("#address-#{@address.id}") do
+        click_button "Delete Address"
+      end
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("#{original_addr_nickname.titlecase} address has been deleted")
+      expect(page).to_not have_content(original_addr_street)
+    end
+
+    it "I can delete an address with associated cancelled orders" do
+      order = create(:cancelled_order, address: @address)
+      original_addr_id = @address.id
+      original_addr_nickname = @address.nickname
+      original_addr_street = @address.street
+
+      visit profile_path
+
+      within("#address-#{@address.id}") do
+        click_button "Delete Address"
+      end
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("#{original_addr_nickname.titlecase} address has been deleted")
+      expect(page).to_not have_content(original_addr_street)
+    end
+
+    it "I can't delete an address with associated packaged orders" do
+      order = create(:packaged_order, address: @address)
       original_addr_id = @address.id
 
       visit profile_path
@@ -75,7 +113,22 @@ RSpec.describe "profile page" do
       end
 
       expect(current_path).to eq(profile_path)
-      expect(page).to have_content("Cannot delete an address that was used for an order")
+      expect(page).to have_content("Cannot delete an address that was used for a packaged order")
+      expect(@address.reload.id).to eq(original_addr_id)
+    end
+
+    it "I can't delete an address with associated shipped orders" do
+      order = create(:shipped_order, address: @address)
+      original_addr_id = @address.id
+
+      visit profile_path
+
+      within("#address-#{@address.id}") do
+        click_button "Delete Address"
+      end
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Cannot delete an address that was used for a shipped order")
       expect(@address.reload.id).to eq(original_addr_id)
     end
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -35,5 +35,22 @@ RSpec.describe Address, type: :model do
       shipped_order = create(:shipped_order, address: address_5)
       expect(address_5.no_completed_orders?).to eq(false)
     end
+
+    it "#delete_addr_and_associations deletes an address and it's presence as a foreign key in any orders and user primary_address" do
+      user = create(:user)
+      address = create(:address, user: user)
+      user.update(primary_address_id: address.id)
+      order = create(:shipped_order, user: user, address: address)
+
+      address.delete_addr_and_associations
+
+      user.reload
+      order.reload
+
+      expect(user.primary_address_id).to eq(nil)
+      expect(user.addresses.count).to eq(0)
+      expect(Address.count).to eq(0)
+      expect(order.address_id).to eq(nil)
+    end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -15,13 +15,25 @@ RSpec.describe Address, type: :model do
   end
 
   describe "instance methods" do
-    it "#no_orders? returns true if the address has no associated orders" do
+    it "#no_completed_orders? returns true if the address has no associated shipped/packaged orders" do
       address_1 = create(:address)
-      address_2 = create(:address)
-      order = create(:order, address: address_1)
+      expect(address_1.no_completed_orders?).to eq(true)
 
-      expect(address_1.no_orders?).to eq(false)
-      expect(address_2.no_orders?).to eq(true)
+      address_2 = create(:address)
+      pending_order = create(:order, address: address_2)
+      expect(address_2.no_completed_orders?).to eq(true)
+
+      address_3 = create(:address)
+      cancelled_order = create(:cancelled_order, address: address_3)
+      expect(address_3.no_completed_orders?).to eq(true)
+
+      address_4 = create(:address)
+      packaged_order = create(:packaged_order, address: address_4)
+      expect(address_4.no_completed_orders?).to eq(false)
+
+      address_5 = create(:address)
+      shipped_order = create(:shipped_order, address: address_5)
+      expect(address_5.no_completed_orders?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
This PR/branch...
 - Resolves #3 (adds ability to delete addresses that have been associated with pending & cancelled orders, but still not shipped or packaged orders)