### PR TITLE
Bulk discounts

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -8,7 +8,6 @@ class CartsController < ApplicationController
     redirect_to items_path
   end
 
-
   def increment
     item = Item.find(params[:id])
     add_to_cart(item)
@@ -52,7 +51,7 @@ class CartsController < ApplicationController
   def checkout
     new_order = current_user.orders.create!(order_params)
     cart.item_and_quantity_hash.each do |item, quantity|
-      OrderItem.create(item: item, order: new_order, quantity: quantity, price_per_item: item.price)
+      OrderItem.create(item: item, order: new_order, quantity: quantity, price_per_item: item.bulk_price(quantity))
     end
     session.delete(:cart)
     flash[:success] = "Your order was created!"

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -5,4 +5,7 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
 
   def new
   end
+
+  def edit
+  end
 end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -24,12 +24,16 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
 
   def update
     @bulk_discount = BulkDiscount.find(params[:id])
-    if @bulk_discount.update(bulk_discount_params)
-      flash[:success] = "The bulk discount was updated"
-      redirect_to merchant_bulk_discounts_path
+    if current_user.id == @bulk_discount.user_id
+      if @bulk_discount.update(bulk_discount_params)
+        flash[:success] = "The bulk discount was updated"
+        redirect_to merchant_bulk_discounts_path
+      else
+        flash[:danger] = @bulk_discount.errors.full_messages.join(". ")
+        render :edit
+      end
     else
-      flash[:danger] = @bulk_discount.errors.full_messages.join(". ")
-      render :edit
+      render file: "/public/404", status: 404
     end
   end
 

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -1,0 +1,5 @@
+class Merchant::BulkDiscountsController < Merchant::BaseController
+  def index
+    @bulk_discounts = current_user.bulk_discounts.where.not(id: nil)
+  end
+end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -13,9 +13,9 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
     bulk_discount = BulkDiscount.find(params[:id])
     if current_user.id == bulk_discount.user_id
       bulk_discount.destroy
+      redirect_to merchant_bulk_discounts_path
     else
       render file: "/public/404", status: 404
     end
-    redirect_to merchant_bulk_discounts_path
   end
 end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -4,6 +4,18 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
   end
 
   def new
+    @bulk_discount = BulkDiscount.new
+  end
+
+  def create
+    bulk_discount = BulkDiscount.new(bulk_discount_params)
+    if bulk_discount.save
+      flash[:success] = "A new bulk discount was added"
+      redirect_to merchant_bulk_discounts_path
+    else
+      flash[:danger] = bulk_discount.errors.full_messages.join(". ")
+      render :new
+    end
   end
 
   def edit
@@ -17,5 +29,12 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
     else
       render file: "/public/404", status: 404
     end
+  end
+
+  private
+
+  def bulk_discount_params
+    params[:bulk_discount][:user_id] = current_user.id
+    params.require(:bulk_discount).permit(:bulk_quantity, :pc_off, :user_id)
   end
 end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -8,4 +8,14 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
 
   def edit
   end
+
+  def destroy
+    bulk_discount = BulkDiscount.find(params[:id])
+    if current_user.id == bulk_discount.user_id
+      bulk_discount.destroy
+    else
+      render file: "/public/404", status: 404
+    end
+    redirect_to merchant_bulk_discounts_path
+  end
 end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -8,13 +8,13 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
   end
 
   def create
-    bulk_discount = BulkDiscount.new(bulk_discount_params)
-    if bulk_discount.save
+    @bulk_discount = BulkDiscount.new(bulk_discount_params)
+    if @bulk_discount.save
       flash[:success] = "A new bulk discount was added"
       redirect_to merchant_bulk_discounts_path
     else
-      flash[:danger] = bulk_discount.errors.full_messages.join(". ")
-      redirect_to new_merchant_bulk_discount_path
+      flash[:danger] = @bulk_discount.errors.full_messages.join(". ")
+      render :new
     end
   end
 

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -2,4 +2,7 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
   def index
     @bulk_discounts = current_user.bulk_discounts.where.not(id: nil)
   end
+
+  def new
+  end
 end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -14,7 +14,7 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
       redirect_to merchant_bulk_discounts_path
     else
       flash[:danger] = bulk_discount.errors.full_messages.join(". ")
-      render :new
+      redirect_to new_merchant_bulk_discount_path
     end
   end
 

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -19,6 +19,18 @@ class Merchant::BulkDiscountsController < Merchant::BaseController
   end
 
   def edit
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
+
+  def update
+    @bulk_discount = BulkDiscount.find(params[:id])
+    if @bulk_discount.update(bulk_discount_params)
+      flash[:success] = "The bulk discount was updated"
+      redirect_to merchant_bulk_discounts_path
+    else
+      flash[:danger] = @bulk_discount.errors.full_messages.join(". ")
+      render :edit
+    end
   end
 
   def destroy

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,0 +1,6 @@
+class BulkDiscount < ApplicationRecord
+  belongs_to :user
+
+  validates :bulk_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 2 }
+  validates :pc_off, numericality: { greater_than_or_equal_to: 0.01 }
+end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -2,5 +2,5 @@ class BulkDiscount < ApplicationRecord
   belongs_to :user
 
   validates :bulk_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 2 }
-  validates :pc_off, numericality: { greater_than_or_equal_to: 0.01 }
+  validates :pc_off, numericality: { greater_than_or_equal_to: 0.01, less_than_or_equal_to: 99.99 }
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -25,12 +25,12 @@ class Cart
 
   def subtotal(item)
     quantity = item_and_quantity_hash[item]
-    item.price * quantity
+    item.bulk_price(quantity) * quantity
   end
 
   def grand_total
     item_and_quantity_hash.sum do |item, quantity|
-      item.price * quantity
+      item.bulk_price(quantity) * quantity
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -63,9 +63,13 @@ class Item < ApplicationRecord
 
   def bulk_price(quantity)
     percent_off = 0
-    if discount = user.highest_applicable_discount(quantity)
+    if discount = highest_applicable_discount(quantity)
       percent_off = discount.pc_off
     end
     price * (100 - percent_off) / 100.0
+  end
+
+  def highest_applicable_discount(quantity)
+    user.highest_applicable_discount(quantity)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -56,12 +56,16 @@ class Item < ApplicationRecord
     order_items.where("order_items.order_id=?", order.id)
   end
 
-  def sufficient_inventory(order)
-    item_quantity = self.order_items.where("order_items.order_id=?", order.id).first.quantity
-    if (self.inventory) > item_quantity
-      return true
-    else
-      return false
+  def sufficient_inventory?(order)
+    item_quantity = order_items.where("order_items.order_id=?", order.id).first.quantity
+    inventory > item_quantity
+  end
+
+  def bulk_price(quantity)
+    percent_off = 0
+    if discount = user.highest_applicable_discount(quantity)
+      percent_off = discount.pc_off
     end
+    price * (100 - percent_off) / 100.0
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
   DEFAULT_IMAGE = "https://www.ultimate-realty.com/wp-content/uploads/sites/6518/2019/04/Image-Coming-Soon.png"
 
   def self.active_items
-    self.where(active: true)
+    self.where(active: true).order(:id)
   end
 
   def self.sort_by_popularity(limit, direction)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,4 +169,10 @@ class User < ApplicationRecord
     update(role: "user")
     items.update_all(active: false)
   end
+
+  def highest_applicable_discount(quantity)
+    bulk_discounts.where("bulk_discounts.bulk_quantity <= ?", quantity)
+                  .order("bulk_discounts.pc_off DESC")
+                  .first
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
                         :role
   has_many :orders
   has_many :items
+  has_many :bulk_discounts
   has_one :primary_address, class_name: 'Address'
 
   has_many :addresses, dependent: :destroy

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -8,8 +8,8 @@
             <h5 class="card-title"><%= link_to item.name, item_path(item) %></h5>
             <p class="card-text"><%= item.user.name %></p>
             <p class="card-text">
-              <%= "Bulk discount applied (#{number_to_percentage(item.highest_applicable_discount(quantity).pc_off, precision: 2)} off orders of #{item.highest_applicable_discount(quantity).bulk_quantity} or more)" if item.highest_applicable_discount(quantity) %>
-              <%= number_to_currency(item.bulk_price(quantity)) %>
+              <%= "Bulk discount applied (#{number_to_percentage(item.highest_applicable_discount(quantity).pc_off, precision: 2)} off orders of #{item.highest_applicable_discount(quantity).bulk_quantity} or more):" if item.highest_applicable_discount(quantity) %>
+              <%= number_to_currency(item.bulk_price(quantity)) %> each
             </p>
             <div class="quantities" >
               Quantity:<%= button_to "-", cart_decrement_item_path(item), method: :patch%><%= quantity %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -7,7 +7,10 @@
           <div class="card-body">
             <h5 class="card-title"><%= link_to item.name, item_path(item) %></h5>
             <p class="card-text"><%= item.user.name %></p>
-            <p class="card-text"><%= number_to_currency(item.price) %></p>
+            <p class="card-text">
+              <%= "Bulk discount applied (#{number_to_percentage(item.highest_applicable_discount(quantity).pc_off, precision: 2)} off orders of #{item.highest_applicable_discount(quantity).bulk_quantity} or more)" if item.highest_applicable_discount(quantity) %>
+              <%= number_to_currency(item.bulk_price(quantity)) %>
+            </p>
             <div class="quantities" >
               Quantity:<%= button_to "-", cart_decrement_item_path(item), method: :patch%><%= quantity %>
               <%= button_to "+", cart_increment_item_path(item), method: :patch %>

--- a/app/views/merchant/bulk_discounts/edit.html.erb
+++ b/app/views/merchant/bulk_discounts/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit Bulk Discount</h1>
+<%= form_for @bulk_discount, url: merchant_bulk_discount_path(@bulk_discount) do |f| %>
+  <%= f.label :bulk_quantity, "Item quantity to qualify for discount" %>
+  <%= f.number_field :bulk_quantity, min: 2 %>
+  <br>
+  <%= f.label :pc_off, "Percent off (enter 50 for 50% off)" %>
+  <%= f.number_field :pc_off, min: 0.01, step: 0.01 %>
+  <br>
+  <%= f.submit "Update Bulk Discount" %>
+<% end %>

--- a/app/views/merchant/bulk_discounts/index.html.erb
+++ b/app/views/merchant/bulk_discounts/index.html.erb
@@ -1,8 +1,12 @@
 <h1>All Bulk Discounts:</h1>
-<% @bulk_discounts.each do |bulk_discount| %>
-  <div id="bulk-discount-<%= bulk_discount.id %>">
-    <p><%= number_to_percentage(bulk_discount.pc_off, precision: 2) %> off when a user purchases at least <%= bulk_discount.bulk_quantity %> of an item</p>
-  </div>
-<% end %>
-<br>
+<ul>
+  <% @bulk_discounts.each do |bulk_discount| %>
+    <div id="bulk-discount-<%= bulk_discount.id %>">
+      <li><%= number_to_percentage(bulk_discount.pc_off, precision: 2) %> off when a user purchases at least <%= bulk_discount.bulk_quantity %> of an item
+      <%= link_to "Edit Discount", edit_merchant_bulk_discount_path(bulk_discount), class: "btn btn-primary" %>
+      </li>
+      <br>
+    </div>
+  <% end %>
+</ul>
 <%= link_to "Add a New Bulk Discount", new_merchant_bulk_discount_path %>

--- a/app/views/merchant/bulk_discounts/index.html.erb
+++ b/app/views/merchant/bulk_discounts/index.html.erb
@@ -1,1 +1,8 @@
+<h1>All Bulk Discounts:</h1>
+<% @bulk_discounts.each do |bulk_discount| %>
+  <div id="bulk-discount-<%= bulk_discount.id %>">
+    <p><%= number_to_percentage(bulk_discount.pc_off, precision: 2) %> off when a user purchases at least <%= bulk_discount.bulk_quantity %> of an item</p>
+  </div>
+<% end %>
+<br>
 <%= link_to "Add a New Bulk Discount", new_merchant_bulk_discount_path %>

--- a/app/views/merchant/bulk_discounts/index.html.erb
+++ b/app/views/merchant/bulk_discounts/index.html.erb
@@ -4,6 +4,7 @@
     <div id="bulk-discount-<%= bulk_discount.id %>">
       <li><%= number_to_percentage(bulk_discount.pc_off, precision: 2) %> off when a user purchases at least <%= bulk_discount.bulk_quantity %> of an item
       <%= link_to "Edit Discount", edit_merchant_bulk_discount_path(bulk_discount), class: "btn btn-primary" %>
+      <%= button_to "Delete Discount", merchant_bulk_discount_path(bulk_discount), method: "delete", class: "btn btn-primary" %>
       </li>
       <br>
     </div>

--- a/app/views/merchant/bulk_discounts/index.html.erb
+++ b/app/views/merchant/bulk_discounts/index.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Add a New Bulk Discount", new_merchant_bulk_discount_path %>

--- a/app/views/merchant/bulk_discounts/index.html.erb
+++ b/app/views/merchant/bulk_discounts/index.html.erb
@@ -4,7 +4,7 @@
     <div id="bulk-discount-<%= bulk_discount.id %>">
       <li><%= number_to_percentage(bulk_discount.pc_off, precision: 2) %> off when a user purchases at least <%= bulk_discount.bulk_quantity %> of an item
       <%= link_to "Edit Discount", edit_merchant_bulk_discount_path(bulk_discount), class: "btn btn-primary" %>
-      <%= button_to "Delete Discount", merchant_bulk_discount_path(bulk_discount), method: "delete", class: "btn btn-primary" %>
+      <%= button_to "Delete Discount", merchant_bulk_discount_path(bulk_discount), method: "delete", class: "btn btn-primary", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %>
       </li>
       <br>
     </div>

--- a/app/views/merchant/bulk_discounts/new.html.erb
+++ b/app/views/merchant/bulk_discounts/new.html.erb
@@ -1,0 +1,9 @@
+<%= form_for @bulk_discount, url: merchant_bulk_discounts_path do |f| %>
+  <%= f.label :bulk_quantity, "Item quantity to qualify for discount" %>
+  <%= f.number_field :bulk_quantity, min: 2 %>
+  <br>
+  <%= f.label :pc_off, "Percent off (enter 50 for 50% off)" %>
+  <%= f.number_field :pc_off, min: 0.01 %>
+  <br>
+  <%= f.submit "Create Bulk Discount" %>
+<% end %>

--- a/app/views/merchant/bulk_discounts/new.html.erb
+++ b/app/views/merchant/bulk_discounts/new.html.erb
@@ -1,9 +1,10 @@
+<h1>Add a New Bulk Discount</h1>
 <%= form_for @bulk_discount, url: merchant_bulk_discounts_path do |f| %>
   <%= f.label :bulk_quantity, "Item quantity to qualify for discount" %>
   <%= f.number_field :bulk_quantity, min: 2 %>
   <br>
   <%= f.label :pc_off, "Percent off (enter 50 for 50% off)" %>
-  <%= f.number_field :pc_off, min: 0.01 %>
+  <%= f.number_field :pc_off, min: 0.01, step: 0.01 %>
   <br>
   <%= f.submit "Create Bulk Discount" %>
 <% end %>

--- a/app/views/merchant/merchants/show.html.erb
+++ b/app/views/merchant/merchants/show.html.erb
@@ -1,6 +1,7 @@
 <div id="dashboard-show">
   <h1><%= @merchant.name %></h1>
   <%= link_to 'View all items for sale', merchant_items_path %>
+  <%= link_to 'View my bulk discounts', merchant_bulk_discounts_path %>
   <p>Email: <%= @merchant.email %></p>
   <% if @address %>
     <p>Address: <%= @address.street %></p>

--- a/app/views/merchant/merchants/show.html.erb
+++ b/app/views/merchant/merchants/show.html.erb
@@ -1,6 +1,7 @@
 <div id="dashboard-show">
   <h1><%= @merchant.name %></h1>
   <%= link_to 'View all items for sale', merchant_items_path %>
+  <br>
   <%= link_to 'View my bulk discounts', merchant_bulk_discounts_path %>
   <p>Email: <%= @merchant.email %></p>
   <% if @address %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -21,11 +21,11 @@
         <% end %>
 
         <% if item.item_fulfilled?(@order) == false %>
-          <% if item.sufficient_inventory(@order) %>
+          <% if item.sufficient_inventory?(@order) %>
             <% item.item_orders(@order).each do |oi| %>
               <p><%= button_to "Fulfill Item", merchant_fulfill_item_path(oi), method: :patch, class: "btn btn-primary" %></p>
             <% end %>
-          <% elsif (item.item_fulfilled?(@order) == false) && !(item.sufficient_inventory(@order)) %>
+          <% elsif (item.item_fulfilled?(@order) == false) && !(item.sufficient_inventory?(@order)) %>
             <p>You do not have sufficient inventory to fulfill this item.</p>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
 
-    resources :bulk_discounts, only: [:index, :new, :edit, :destroy]
+    resources :bulk_discounts, only: [:index, :new, :create, :edit, :destroy]
   end
 
   # ADMIN ROUTES

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,12 +46,15 @@ Rails.application.routes.draw do
   # DASHBOARD ROUTES (AS A MERCHANT)
   scope :dashboard, module: :merchant, as: :merchant do
     get '/', to: "merchants#show", as: :dashboard
+
     resources :items, only: [:index, :new, :create, :edit, :update, :destroy]
     patch '/items/:id/disable', to: "items#disable", as: :disable_item
     patch '/items/:id/enable', to: "items#enable", as: :enable_item
+
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
-    resources :bulk_discounts, only: [:index]
+
+    resources :bulk_discounts, only: [:index, :new]
   end
 
   # ADMIN ROUTES

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     patch '/items/:id/enable', to: "items#enable", as: :enable_item
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
+    resources :bulk_discounts, only: [:index]
   end
 
   # ADMIN ROUTES

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
 
-    resources :bulk_discounts, only: [:index, :new]
+    resources :bulk_discounts, only: [:index, :new, :edit]
   end
 
   # ADMIN ROUTES

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
 
-    resources :bulk_discounts, only: [:index, :new, :create, :edit, :destroy]
+    resources :bulk_discounts, only: [:index, :new, :create, :edit, :update, :destroy]
   end
 
   # ADMIN ROUTES

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
 
-    resources :bulk_discounts, only: [:index, :new, :edit]
+    resources :bulk_discounts, only: [:index, :new, :edit, :destroy]
   end
 
   # ADMIN ROUTES

--- a/db/migrate/20190603202912_create_bulk_discounts.rb
+++ b/db/migrate/20190603202912_create_bulk_discounts.rb
@@ -1,0 +1,11 @@
+class CreateBulkDiscounts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :bulk_discounts do |t|
+      t.references :user, foreign_key: true
+      t.integer :bulk_quantity
+      t.decimal :pc_off
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190603053005) do
+ActiveRecord::Schema.define(version: 20190603202912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 20190603053005) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
+
+  create_table "bulk_discounts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "bulk_quantity"
+    t.decimal "pc_off"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_bulk_discounts_on_user_id"
   end
 
   create_table "items", force: :cascade do |t|
@@ -74,6 +83,7 @@ ActiveRecord::Schema.define(version: 20190603053005) do
   end
 
   add_foreign_key "addresses", "users"
+  add_foreign_key "bulk_discounts", "users"
   add_foreign_key "items", "users"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"

--- a/spec/factories/bulk_discount.rb
+++ b/spec/factories/bulk_discount.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :bulk_discount do
+    user
+    sequence(:bulk_quantity) { |n| ("#{n}".to_i+1)*2 }
+    sequence(:pc_off) { |n| ("#{n}".to_i+1)*1.5 }
+  end
+end

--- a/spec/features/carts/checkout_spec.rb
+++ b/spec/features/carts/checkout_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe "Cart checkout functionality: " do
       expect(page).to have_content("Shipping to #{@addr_1.nickname} address: #{@addr_1.street}, #{@addr_1.city}, #{@addr_1.state}, #{@addr_1.zip}")
     end
 
+    it "applies bulk discounts when creating an order" do
+      bulk_discount = create(:bulk_discount, user: @merchant_1, bulk_quantity: 2) # will apply for item_1
+
+      visit cart_path
+
+      find('#order_address_id').select(@addr_1.street)
+      click_button 'Check Out'
+
+      new_order = Order.last
+
+      oi_1 = new_order.order_items.first
+      oi_2 = new_order.order_items.last
+
+      expect(oi_1.item_id).to eq(@item_1.id)
+      expect(oi_2.item_id).to eq(@item_2.id)
+
+      expect(oi_1.price_per_item).to eq(@item_1.price * (100 - bulk_discount.pc_off)/100.0)
+      expect(oi_2.price_per_item).to eq(@item_2.price)
+    end
+
     it "defaults to my primary address" do
       visit cart_path
 

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "cart show page", type: :feature do
 
       # 3 of merchant_1's item_2 total - bulk discount does NOT apply (wrong merchant)
       merchant_2 = create(:merchant)
-      item_3 = create(:item, user: merchant_2, name: "Sofa")
+      item_3 = create(:item, user: merchant_2)
       visit item_path(item_3)
       click_button "Add to Cart"
       visit item_path(item_3)
@@ -135,22 +135,22 @@ RSpec.describe "cart show page", type: :feature do
 
       visit cart_path
 
+      item_1_subtotal = 2 * @item_1.price
       within("#item-#{@item_1.id}") do
-        item_1_subtotal = 2 * @item_1.price
         expect(page).to have_content(number_to_currency(@item_1.price))
         expect(page).to have_content("Subtotal: #{number_to_currency(item_1_subtotal)}")
       end
 
+      item_2_subtotal = 3 * @item_2.price * (100-bd_1.pc_off)/100.0
       within("#item-#{@item_2.id}") do
-        item_2_subtotal = 3 * @item_2.price * (100-bd_1.pc_off)/100.0
         expect(page).to have_content("Bulk discount applied (#{number_to_percentage(bd_1.pc_off, precision: 2)} off orders of #{bd_1.bulk_quantity} or more)")
         expect(page).to have_content(number_to_currency(@item_2.price * (100-bd_1.pc_off)/100.0))
         expect(page).to have_content("Subtotal: #{number_to_currency(item_2_subtotal)}")
       end
 
-      within("#item-#{@item_3.id}") do
-        item_3_subtotal = 3 * item_3.price
-        expect(page).to have_content(number_to_currency(@item_2.price))
+      item_3_subtotal = 3 * item_3.price
+      within("#item-#{item_3.id}") do
+        expect(page).to have_content(number_to_currency(item_3.price))
         expect(page).to have_content("Subtotal: #{number_to_currency(item_3_subtotal)}")
       end
 

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe "cart show page", type: :feature do
 
       within("#item-#{@item_2.id}") do
         item_2_subtotal = 3 * @item_2.price * (100-bd_1.pc_off)/100.0
-        expect(page).to have_content(number_to_currency(@item_2.price))
+        expect(page).to have_content("Bulk discount applied (#{number_to_percentage(bd_1.pc_off, precision: 2)} off orders of #{bd_1.bulk_quantity} or more)")
+        expect(page).to have_content(number_to_currency(@item_2.price * (100-bd_1.pc_off)/100.0))
         expect(page).to have_content("Subtotal: #{number_to_currency(item_2_subtotal)}")
       end
 

--- a/spec/features/merchant/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchant/bulk_discounts/edit_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe 'Bulk Discount Edit Form' do
       expect(@bulk_discount.reload.pc_off).to eq(@pc_off)
     end
 
+    it "I cannot edit another merchant's bulk discount" do
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
+
+      @bulk_discount.update!(user: create(:merchant))
+
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Update Bulk Discount"
+
+      expect(status_code).to eq(404)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
+    end
+
     it "requires bulk_quantity input" do
       visit edit_merchant_bulk_discount_path(@bulk_discount)
 

--- a/spec/features/merchant/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchant/bulk_discounts/edit_spec.rb
@@ -3,9 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Bulk Discount Edit Form' do
   describe 'as a merchant' do
     before :each do
+      @orig_quant = 3
+      @orig_pc_off = 45.0
+
       @merchant = create(:merchant)
       address = create(:address, user: @merchant)
-      @bulk_discount = create(:bulk_discount, user: @merchant)
+      @bulk_discount = create(:bulk_discount, user: @merchant, bulk_quantity: @orig_quant, pc_off: @orig_pc_off)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
@@ -31,131 +34,111 @@ RSpec.describe 'Bulk Discount Edit Form' do
     it "requires bulk_quantity input" do
       visit edit_merchant_bulk_discount_path(@bulk_discount)
 
-      # DON'T fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
-      fill_in "bulk_discount[pc_off]", with: @pc_off
+      fill_in "bulk_discount[bulk_quantity]", with: ""
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity is not a number")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
     end
 
     it "bulk_quantity input must be 2 or greater" do
       visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       fill_in "bulk_discount[bulk_quantity]", with: "hello"
-      fill_in "bulk_discount[pc_off]", with: @pc_off
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity is not a number")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: "-5"
-      fill_in "bulk_discount[pc_off]", with: @pc_off
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: 1
-      fill_in "bulk_discount[pc_off]", with: @pc_off
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: 4.5
-      fill_in "bulk_discount[pc_off]", with: @pc_off
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be an integer")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
     end
 
     it "requires pc_off input" do
       visit edit_merchant_bulk_discount_path(@bulk_discount)
 
-      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
-      # DON'T fill_in "bulk_discount[pc_off]", with: @pc_off
+      fill_in "bulk_discount[pc_off]", with: ""
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off is not a number")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
     end
 
     it "pc_off input must be 0.01 or greater" do
       visit edit_merchant_bulk_discount_path(@bulk_discount)
 
-      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: "hello"
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off is not a number")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
 
-      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: "-3.2"
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
 
-      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: 0.0
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
     end
 
     it "pc_off input must be 99.99 or less" do
       visit edit_merchant_bulk_discount_path(@bulk_discount)
 
-      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: 100
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
-      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be less than or equal to 99.99")
-      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
-      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@orig_quant)
+      expect(@bulk_discount.reload.pc_off).to eq(@orig_pc_off)
     end
   end
 end

--- a/spec/features/merchant/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchant/bulk_discounts/edit_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe 'Bulk Discount New Form' do
+RSpec.describe 'Bulk Discount Edit Form' do
   describe 'as a merchant' do
     before :each do
       @merchant = create(:merchant)
       address = create(:address, user: @merchant)
+      @bulk_discount = create(:bulk_discount, user: @merchant)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
@@ -12,141 +13,149 @@ RSpec.describe 'Bulk Discount New Form' do
       @pc_off = 30.0
     end
 
-    it "has a form to add a new bulk discount" do
-      visit new_merchant_bulk_discount_path
+    it "has a form to edit an existing bulk discount" do
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: @pc_off
 
-      click_button "Create Bulk Discount"
+      click_button "Update Bulk Discount"
 
       expect(current_path).to eq(merchant_bulk_discounts_path)
 
-      new_discount = BulkDiscount.last
-
-      expect(page).to have_content("A new bulk discount was added")
-      expect(new_discount.bulk_quantity).to eq(@bulk_quantity)
-      expect(new_discount.pc_off).to eq(@pc_off)
+      expect(page).to have_content("The bulk discount was updated")
+      expect(@bulk_discount.reload.bulk_quantity).to eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to eq(@pc_off)
     end
 
     it "requires bulk_quantity input" do
-      visit new_merchant_bulk_discount_path
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       # DON'T fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity is not a number")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
     end
 
     it "bulk_quantity input must be 2 or greater" do
-      visit new_merchant_bulk_discount_path
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       fill_in "bulk_discount[bulk_quantity]", with: "hello"
       fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity is not a number")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: "-5"
       fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: 1
       fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: 4.5
       fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be an integer")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
     end
 
     it "requires pc_off input" do
-      visit new_merchant_bulk_discount_path
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       # DON'T fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off is not a number")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
     end
 
     it "pc_off input must be 0.01 or greater" do
-      visit new_merchant_bulk_discount_path
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: "hello"
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off is not a number")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: "-3.2"
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
 
       fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: 0.0
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
     end
 
     it "pc_off input must be 99.99 or less" do
-      visit new_merchant_bulk_discount_path
+      visit edit_merchant_bulk_discount_path(@bulk_discount)
 
       fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
       fill_in "bulk_discount[pc_off]", with: 100
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@bulk_discount))
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be less than or equal to 99.99")
-      expect(BulkDiscount.count).to eq(0)
+      expect(@bulk_discount.reload.bulk_quantity).to_not eq(@bulk_quantity)
+      expect(@bulk_discount.reload.pc_off).to_not eq(@pc_off)
     end
   end
 end

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -53,5 +53,24 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
 
       expect(current_path).to eq(edit_merchant_bulk_discount_path(discount_2))
     end
+
+    it "has buttons to delete my bulk discounts" do
+      discount_1 = create(:bulk_discount, user: @merchant)
+      discount_2 = create(:bulk_discount, user: @merchant)
+
+      visit merchant_bulk_discounts_path
+
+      within("#bulk-discount-#{discount_1.id}") do
+        expect(page).to have_button("Delete Discount")
+      end
+
+      within("#bulk-discount-#{discount_2.id}") do
+        click_button "Delete Discount"
+      end
+
+      expect(current_path).to eq(merchant_bulk_discounts_path)
+      expect(page).to_not have_content(discount_2.bulk_quantity)
+      expect(@merchant.bulk_discounts).to eq([discount_1])
+    end
   end
 end

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -36,5 +36,22 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
 
       expect(page).to_not have_content(discount_3.bulk_quantity)
     end
+
+    it "has links to edit my bulk discounts" do
+      discount_1 = create(:bulk_discount, user: @merchant)
+      discount_2 = create(:bulk_discount, user: @merchant)
+
+      visit merchant_bulk_discounts_path
+
+      within("#bulk-discount-#{discount_1.id}") do
+        expect(page).to have_link("Edit Discount")
+      end
+
+      within("#bulk-discount-#{discount_2.id}") do
+        click_link "Edit Discount"
+      end
+
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(discount_2))
+    end
   end
 end

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -16,5 +16,25 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
 
       expect(current_path).to eq(new_merchant_bulk_discount_path)
     end
+
+    it "has a list of all my bulk discounts and their info" do
+      discount_1 = create(:bulk_discount, user: @merchant)
+      discount_2 = create(:bulk_discount, user: @merchant)
+      discount_3 = create(:bulk_discount)
+
+      visit merchant_bulk_discounts_path
+
+      within("#bulk-discount-#{discount_1.id}") do
+        expect(page).to have_content(discount_1.bulk_quantity)
+        expect(page).to have_content(number_to_percentage(discount_1.pc_off, precision: 2))
+      end
+
+      within("#bulk-discount-#{discount_2.id}") do
+        expect(page).to have_content(discount_2.bulk_quantity)
+        expect(page).to have_content(number_to_percentage(discount_2.pc_off, precision: 2))
+      end
+
+      expect(page).to_not have_content(discount_3.bulk_quantity)
+    end
   end
 end

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Bulk Discounts Index' do
+  describe 'as a merchant' do
+    before :each do
+      @merchant = create(:merchant)
+      address = create(:address, user: @merchant)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    end
+
+    it "has a link to add a new bulk discount" do
+      visit merchant_bulk_discounts_path
+
+      click_link "Add a New Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+    end
+  end
+end

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
         expect(page).to have_content(number_to_percentage(discount_2.pc_off, precision: 2))
       end
 
-      expect(page).to_not have_content(discount_3.bulk_quantity)
+      expect(page).to_not have_content("when a user purchases at least #{discount_3.bulk_quantity}")
     end
 
     it "has links to edit my bulk discounts" do

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -72,5 +72,20 @@ RSpec.describe 'Merchant Bulk Discounts Index' do
       expect(page).to_not have_content(discount_2.bulk_quantity)
       expect(@merchant.bulk_discounts).to eq([discount_1])
     end
+
+    it "I cannot delete another merchant's bulk discounts" do
+      discount_1 = create(:bulk_discount, user: @merchant)
+
+      visit merchant_bulk_discounts_path
+
+      discount_1.update(user: create(:merchant))
+
+      within("#bulk-discount-#{discount_1.id}") do
+        click_button "Delete Discount"
+      end
+
+      expect(status_code).to eq(404)
+      expect(BulkDiscount.count).to eq(1)
+    end
   end
 end

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -134,5 +134,19 @@ RSpec.describe 'Bulk Discount Edit Form' do
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
       expect(BulkDiscount.count).to eq(0)
     end
+
+    it "pc_off input must be 99.99 or less" do
+      visit new_merchant_bulk_discount_path
+
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: 100
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Pc off must be less than or equal to 99.99")
+      expect(BulkDiscount.count).to eq(0)
+    end
   end
 end

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity is not a number")
       expect(BulkDiscount.count).to eq(0)
@@ -51,7 +50,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity is not a number")
       expect(BulkDiscount.count).to eq(0)
@@ -61,7 +59,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
       expect(BulkDiscount.count).to eq(0)
@@ -71,7 +68,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
       expect(BulkDiscount.count).to eq(0)
@@ -81,7 +77,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Bulk quantity must be an integer")
       expect(BulkDiscount.count).to eq(0)
@@ -95,7 +90,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off is not a number")
       expect(BulkDiscount.count).to eq(0)
@@ -109,7 +103,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off is not a number")
       expect(BulkDiscount.count).to eq(0)
@@ -119,7 +112,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
       expect(BulkDiscount.count).to eq(0)
@@ -129,7 +121,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be greater than or equal to 0.01")
       expect(BulkDiscount.count).to eq(0)
@@ -143,7 +134,6 @@ RSpec.describe 'Bulk Discount New Form' do
 
       click_button "Create Bulk Discount"
 
-      expect(current_path).to eq(new_merchant_bulk_discount_path)
       expect(page).to have_field("bulk_discount[bulk_quantity]")
       expect(page).to have_content("Pc off must be less than or equal to 99.99")
       expect(BulkDiscount.count).to eq(0)

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Bulk Discount Edit Form' do
+  describe 'as a merchant' do
+    before :each do
+      @merchant = create(:merchant)
+      address = create(:address, user: @merchant)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    end
+
+    it "has a form to add a new bulk discount" do
+      visit new_merchant_bulk_discount_path
+
+      bulk_quantity = 6
+      pc_off = 30.0
+
+      fill_in "bulk_discount[bulk_quantity]", with: bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(merchant_bulk_discounts_path)
+
+      new_discount = BulkDiscount.last
+
+      expect(page).to have_content("A new bulk discount was added")
+      expect(new_discount.bulk_quantity).to eq(bulk_quantity)
+      expect(new_discount.pc_off).to eq(pc_off)
+    end
+  end
+end

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe 'Bulk Discount Edit Form' do
       address = create(:address, user: @merchant)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
+      @bulk_quantity = 6
+      @pc_off = 30.0
     end
 
     it "has a form to add a new bulk discount" do
       visit new_merchant_bulk_discount_path
 
-      bulk_quantity = 6
-      pc_off = 30.0
-
-      fill_in "bulk_discount[bulk_quantity]", with: bulk_quantity
-      fill_in "bulk_discount[pc_off]", with: pc_off
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: @pc_off
 
       click_button "Create Bulk Discount"
 
@@ -25,8 +25,114 @@ RSpec.describe 'Bulk Discount Edit Form' do
       new_discount = BulkDiscount.last
 
       expect(page).to have_content("A new bulk discount was added")
-      expect(new_discount.bulk_quantity).to eq(bulk_quantity)
-      expect(new_discount.pc_off).to eq(pc_off)
+      expect(new_discount.bulk_quantity).to eq(@bulk_quantity)
+      expect(new_discount.pc_off).to eq(@pc_off)
+    end
+
+    it "requires bulk_quantity input" do
+      visit new_merchant_bulk_discount_path
+
+      # DON'T fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Bulk quantity is not a number")
+      expect(BulkDiscount.count).to eq(0)
+    end
+
+    it "bulk_quantity input must be 2 or greater" do
+      visit new_merchant_bulk_discount_path
+
+      fill_in "bulk_discount[bulk_quantity]", with: "hello"
+      fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Bulk quantity is not a number")
+      expect(BulkDiscount.count).to eq(0)
+
+      fill_in "bulk_discount[bulk_quantity]", with: "-5"
+      fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
+      expect(BulkDiscount.count).to eq(0)
+
+      fill_in "bulk_discount[bulk_quantity]", with: 1
+      fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Bulk quantity must be greater than or equal to 2")
+      expect(BulkDiscount.count).to eq(0)
+
+      fill_in "bulk_discount[bulk_quantity]", with: 4.5
+      fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Bulk quantity must be an integer")
+      expect(BulkDiscount.count).to eq(0)
+    end
+
+    it "requires pc_off input" do
+      visit new_merchant_bulk_discount_path
+
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      # DON'T fill_in "bulk_discount[pc_off]", with: @pc_off
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Pc off is not a number")
+      expect(BulkDiscount.count).to eq(0)
+    end
+
+    it "pc_off input must be 0.01 or greater" do
+      visit new_merchant_bulk_discount_path
+
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: "hello"
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Pc off is not a number")
+      expect(BulkDiscount.count).to eq(0)
+
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: "-3.2"
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Pc off must be greater than or equal to 0.01")
+      expect(BulkDiscount.count).to eq(0)
+
+      fill_in "bulk_discount[bulk_quantity]", with: @bulk_quantity
+      fill_in "bulk_discount[pc_off]", with: 0.0
+
+      click_button "Create Bulk Discount"
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path)
+      expect(page).to have_field("bulk_discount[bulk_quantity]")
+      expect(page).to have_content("Pc off must be greater than or equal to 0.01")
+      expect(BulkDiscount.count).to eq(0)
     end
   end
 end

--- a/spec/features/merchant/merchants/show_spec.rb
+++ b/spec/features/merchant/merchants/show_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe 'As a merchant user: ' do
         expect(page).to_not have_content(@other_merchant.name)
       end
     end
+
+    it "has a link to see my bulk discounts" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
+      visit merchant_dashboard_path
+      click_link "View my bulk discounts"
+
+      expect(current_path).to eq(merchant_bulk_discounts_path)
+    end
   end
 
   describe "when I have orders" do

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe BulkDiscount, type: :model do
     it {should validate_numericality_of(:bulk_quantity).only_integer}
     it {should validate_numericality_of(:bulk_quantity).is_greater_than_or_equal_to(2)}
     it {should validate_numericality_of(:pc_off).is_greater_than_or_equal_to(0.01)}
+    it {should validate_numericality_of(:pc_off).is_less_than_or_equal_to(99.99)}
   end
 
   describe "relationships" do

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe BulkDiscount, type: :model do
+  describe "validations" do
+    it {should validate_numericality_of(:bulk_quantity).only_integer}
+    it {should validate_numericality_of(:bulk_quantity).is_greater_than_or_equal_to(2)}
+    it {should validate_numericality_of(:pc_off).is_greater_than_or_equal_to(0.01)}
+  end
+
+  describe "relationships" do
+    it { should belong_to :user}
+  end
+end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Cart do
       expect(cart_1.subtotal(item_1)).to eq(2 * item_1.price)
       expect(cart_1.subtotal(item_2)).to eq(3 * item_2.price)
     end
+
+    it "calculates the subtotal for a particular item (incorporating bulk discounts if applicable)" do
+      item_1 = create(:item)
+      item_2 = create(:item)
+      bulk_discount = create(:bulk_discount, user: item_2.user, bulk_quantity: 3)
+      cart_1 = Cart.new({item_1.id.to_s => 2, item_2.id.to_s => 3})
+
+      expect(cart_1.subtotal(item_1)).to eq(2 * item_1.price)
+      expect(cart_1.subtotal(item_2)).to eq(3 * item_2.price * (100 - bulk_discount.pc_off)/100.0)
+    end
   end
 
   describe "#grand_total" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -212,5 +212,20 @@ RSpec.describe Item, type: :model do
       expect(item_1.bulk_price(6)).to eq(item_1.price * (100 - bulk_discount_2.pc_off)/100.0)
       expect(item_1.bulk_price(11)).to eq(item_1.price * (100 - bulk_discount_2.pc_off)/100.0) # not bulk_discount_3 because it's not as good of a deal
     end
+
+    it "#highest_applicable_discount returns the best applicable discount (highest percent off)" do
+      merchant_1 = create(:merchant)
+      item_1 = create(:item, user: merchant_1)
+      bulk_discount_1 = create(:bulk_discount, user: merchant_1, bulk_quantity: 3, pc_off: 4)
+      bulk_discount_2 = create(:bulk_discount, user: merchant_1, bulk_quantity: 5, pc_off: 20)
+      bulk_discount_3 = create(:bulk_discount, user: merchant_1, bulk_quantity: 10, pc_off: 8)
+
+      expect(item_1.highest_applicable_discount(1)).to eq(nil)
+      expect(item_1.highest_applicable_discount(2)).to eq(nil)
+      expect(item_1.highest_applicable_discount(3)).to eq(bulk_discount_1)
+      expect(item_1.highest_applicable_discount(5)).to eq(bulk_discount_2)
+      expect(item_1.highest_applicable_discount(6)).to eq(bulk_discount_2)
+      expect(item_1.highest_applicable_discount(11)).to eq(bulk_discount_2) # not bulk_discount_3 because it's not as good of a deal
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Item, type: :model do
       expect(item_2.purchase_quantity(order_2)).to eq(oi_3.quantity)
     end
 
-    it "#item_fulfilled? returns true/false for fulfilled, #sufficient_inventory returns true/false" do
+    it "#item_fulfilled? returns true/false for fulfilled, #sufficient_inventory? returns true/false" do
       user = create(:user)
       order_1 = create(:order, user: user)
       order_4 = create(:order, user: user)
@@ -176,9 +176,9 @@ RSpec.describe Item, type: :model do
       expect(item_2.item_fulfilled?(order_2)).to eq(false)
       expect(item_2.item_fulfilled?(order_1)).to eq(false)
 
-      expect(item_4.sufficient_inventory(order_2)).to eq(false)
-      expect(item_2.sufficient_inventory(order_2)).to eq(true)
-      expect(item_2.sufficient_inventory(order_1)).to eq(true)
+      expect(item_4.sufficient_inventory?(order_2)).to eq(false)
+      expect(item_2.sufficient_inventory?(order_2)).to eq(true)
+      expect(item_2.sufficient_inventory?(order_1)).to eq(true)
     end
 
     it "#item_orders returns order_item objects for a specific item in an order" do
@@ -196,6 +196,21 @@ RSpec.describe Item, type: :model do
 
       expect(item_1.item_orders(order_1)).to eq([oi_1])
       expect(item_1.item_orders(order_2)).to eq([oi_2])
+    end
+
+    it "#bulk_price returns the bulk price of an item when given a quantity" do
+      merchant_1 = create(:merchant)
+      item_1 = create(:item, user: merchant_1)
+      bulk_discount_1 = create(:bulk_discount, user: merchant_1, bulk_quantity: 3, pc_off: 4)
+      bulk_discount_2 = create(:bulk_discount, user: merchant_1, bulk_quantity: 5, pc_off: 20)
+      bulk_discount_3 = create(:bulk_discount, user: merchant_1, bulk_quantity: 10, pc_off: 8)
+
+      expect(item_1.bulk_price(1)).to eq(item_1.price)
+      expect(item_1.bulk_price(2)).to eq(item_1.price)
+      expect(item_1.bulk_price(3)).to eq(item_1.price * (100 - bulk_discount_1.pc_off)/100.0)
+      expect(item_1.bulk_price(5)).to eq(item_1.price * (100 - bulk_discount_2.pc_off)/100.0)
+      expect(item_1.bulk_price(6)).to eq(item_1.price * (100 - bulk_discount_2.pc_off)/100.0)
+      expect(item_1.bulk_price(11)).to eq(item_1.price * (100 - bulk_discount_2.pc_off)/100.0) # not bulk_discount_3 because it's not as good of a deal
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe User, type: :model do
     it {should have_many :items}
     it {should have_many :orders}
     it {should have_many :addresses}
+    it {should have_many :bulk_discounts}
     it {should have_one :primary_address}
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -368,5 +368,21 @@ RSpec.describe User, type: :model do
       expect(@merchant_1.reload.role).to eq("user")
       expect(@item_1.reload.active).to eq(false)
     end
+
+    it "when called on a merchant, #highest_applicable_discount returns the highest bulk discount pc_off that applies for the quantity ordered" do
+      merchant = create(:merchant)
+      bd_1 = create(:bulk_discount, user: merchant, bulk_quantity: 3, pc_off: 3)
+      bd_2 = create(:bulk_discount, user: merchant, bulk_quantity: 5, pc_off: 30)
+      bd_3 = create(:bulk_discount, user: merchant, bulk_quantity: 7, pc_off: 10)
+
+      # no bulk discounts apply:
+      expect(merchant.highest_applicable_discount(2)).to eq(nil)
+      # only bd_1 applies:
+      expect(merchant.highest_applicable_discount(3)).to eq(bd_1)
+      # bd_1 & bd_2 apply, bd_2 is a better discount:
+      expect(merchant.highest_applicable_discount(6)).to eq(bd_2)
+      # bd_1, bd_2, & bd_3 all apply, but bd_2 is the best discount:
+      expect(merchant.highest_applicable_discount(10)).to eq(bd_2)
+    end
   end
 end


### PR DESCRIPTION
This PR/branch...
 - Adds a `bulk_discounts` table for merchants to add a percent-off (`pc_off`) discount that applies if a single item in an order has a quantity >= the `bulk_quantity`. Merchants have full CRUD abilities for their own `bulk_discounts`.
 - Bulk discounts show up / are applied in the cart, and are applied in the `order_items` table's `price_per_item` column (and therefore on order show pages)