### PR TITLE
Make it so you can't edit addresses associated with completed orders

### DIFF
--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -19,6 +19,9 @@ class User::AddressesController < User::BaseController
   def edit
     @user = current_user
     @address = Address.find(params[:id])
+    if @address.user_id != current_user.id
+      render file: "/public/404", status: 404
+    end
   end
 
   def update

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -22,6 +22,20 @@ class User::AddressesController < User::BaseController
   end
 
   def update
+    @address = Address.find(params[:id])
+    if @address.user_id == current_user.id
+      if @address.update(address_params)
+        flash[:success] = "Updated \"#{params[:address][:nickname]}\" address"
+        redirect_to profile_path
+      else
+        flash[:danger] = @address.errors.full_messages.join(". ")
+        @user = current_user
+        render :edit
+      end
+
+    else
+      render file: "/public/404", status: 404
+    end
   end
 
   def destroy
@@ -46,6 +60,6 @@ class User::AddressesController < User::BaseController
 
   def address_params
     params[:address][:user_id] = current_user.id
-    params.require(:address).permit(:nickname, :street, :city, :state, :zip, :user_id)
+    params.require(:address).permit(:id, :nickname, :street, :city, :state, :zip, :user_id)
   end
 end

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -16,6 +16,14 @@ class User::AddressesController < User::BaseController
     end
   end
 
+  def edit
+    @user = current_user
+    @address = Address.find(params[:id])
+  end
+
+  def update
+  end
+
   def destroy
     address = Address.find(params[:id])
     if address.user_id == current_user.id

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -27,15 +27,19 @@ class User::AddressesController < User::BaseController
   def update
     @address = Address.find(params[:id])
     if @address.user_id == current_user.id
-      if @address.update(address_params)
-        flash[:success] = "Updated \"#{params[:address][:nickname]}\" address"
-        redirect_to profile_path
+      if @address.no_completed_orders?
+        if @address.update(address_params)
+          flash[:success] = "Updated \"#{params[:address][:nickname]}\" address"
+          redirect_to profile_path
+        else
+          flash[:danger] = @address.errors.full_messages.join(". ")
+          @user = current_user
+          render :edit
+        end
       else
-        flash[:danger] = @address.errors.full_messages.join(". ")
-        @user = current_user
-        render :edit
+        flash[:danger] = "Cannot change an address that was used for packaged/shipped order(s)"
+        redirect_back fallback_location: profile_path
       end
-
     else
       render file: "/public/404", status: 404
     end

--- a/app/controllers/user/orders_controller.rb
+++ b/app/controllers/user/orders_controller.rb
@@ -31,11 +31,11 @@ class User::OrdersController < User::BaseController
   private
 
   def change_address
-    if @order.status == "pending"
+    if @order.status == "pending" || @order.status == "cancelled"
       @order.update(address_id: params[:order][:address_id])
       flash[:success] = "Shipping address succcessfully changed"
     else
-      flash[:danger] = "Shipping address can only be changed for pending orders"
+      flash[:danger] = "Shipping address cannot be changed for completed orders"
     end
   end
 end

--- a/app/views/user/addresses/edit.html.erb
+++ b/app/views/user/addresses/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@user, @address] do |f| %>
+<%= form_for @address, url: user_address_path(@address.id) do |f| %>
   <%= f.label :nickname %>
   <%= f.text_field :nickname %>
   <br>

--- a/app/views/user/addresses/edit.html.erb
+++ b/app/views/user/addresses/edit.html.erb
@@ -1,0 +1,18 @@
+<%= form_for [@user, @address] do |f| %>
+  <%= f.label :nickname %>
+  <%= f.text_field :nickname %>
+  <br>
+  <%= f.label :street %>
+  <%= f.text_field :street, required: true %>
+  <br>
+  <%= f.label :city %>
+  <%= f.text_field :city, required: true %>
+  <br>
+  <%= f.label :state %>
+  <%= f.text_field :state, required: true %>
+  <br>
+  <%= f.label :zip %>
+  <%= f.text_field :zip, required: true %>
+  <br>
+  <%= f.submit "Update Address" %>
+<% end %>

--- a/app/views/user/users/edit.html.erb
+++ b/app/views/user/users/edit.html.erb
@@ -12,25 +12,6 @@
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, value: "" %>
     <br><br>
-
-    <%= f.fields_for :addresses do |c| %>
-      <%= c.label :nickname, "Address Nickname" %>
-      <%= c.text_field :nickname %>
-      <br>
-      <%= c.label :street, "Street Address" %>
-      <%= c.text_field :street, required: true %>
-      <br>
-      <%= c.label :city %>
-      <%= c.text_field :city, required: true %>
-      <br>
-      <%= c.label :state %>
-      <%= c.text_field :state, required: true %>
-      <br>
-      <%= c.label :zip %>
-      <%= c.text_field :zip, required: true %>
-      <br><br>
-    <% end %>
-
     <%= f.submit "Submit Changes" %>
   <% end %>
 </div>

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -14,6 +14,7 @@
         <li><%= address.street %></li>
         <li><%= address.city %>, <%= address.state %></li>
         <li><%= address.zip %></li>
+        <li><%= link_to "Edit Address", edit_user_address_path(address), class: "btn btn-primary" %></li>
         <li><%= button_to "Delete Address", delete_address_path(address), method: "delete", class: "btn btn-primary", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %></li>
       </ul>
     </div>

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -14,8 +14,10 @@
         <li><%= address.street %></li>
         <li><%= address.city %>, <%= address.state %></li>
         <li><%= address.zip %></li>
-        <li><%= link_to "Edit Address", edit_user_address_path(address), class: "btn btn-primary" %></li>
-        <li><%= button_to "Delete Address", delete_address_path(address), method: "delete", class: "btn btn-primary", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %></li>
+        <% if address.no_completed_orders? %>
+          <li><%= link_to "Edit Address", edit_user_address_path(address), class: "btn btn-primary" %></li>
+          <li><%= button_to "Delete Address", delete_address_path(address), method: "delete", class: "btn btn-primary", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %></li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   patch '/users/:id', to: "user/users#update", as: :user
   delete '/addresses/:id', to: "user/addresses#destroy", as: :delete_address
   namespace :user do
-    resources :addresses, only: [:new, :create]
+    resources :addresses, only: [:new, :create, :edit, :update]
   end
 
   scope :profile, module: :user, as: :user do

--- a/spec/features/user/addresses/edit_spec.rb
+++ b/spec/features/user/addresses/edit_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe "Editing an existing address" do
+  context "as a logged in regular user" do
+    before(:each) do
+      @user_1 = create(:user)
+      @addr_1 = create(:address, user: @user_1)
+      @addr_2 = create(:address, user: @user_1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+      @nickname = "my work"
+      @street = "123 go to santa lane"
+      @city = "aurora"
+      @state = "colorado"
+      @zip = "123311"
+    end
+
+    it "I can edit an address from the profile page" do
+      visit profile_path
+
+      within("#address-#{@addr_1.id}") do
+        click_link "Edit Address"
+      end
+
+      expect(current_path).to eq(edit_user_address_path(@addr_1))
+    end
+
+    it "has a form to edit an address" do
+      visit edit_user_address_path(@addr_1)
+
+      fill_in "address[nickname]", with: @nickname
+      fill_in "address[street]", with: @street
+      fill_in "address[city]", with: @city
+      fill_in "address[state]", with: @state
+      fill_in "address[zip]", with: @zip
+
+      click_on "Update Address"
+
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content("Updated \"#{nickname}\" address")
+      expect(new_address.nickname).to eq(@nickname)
+      expect(new_address.street).to eq(@street)
+      expect(new_address.city).to eq(@city)
+      expect(new_address.state).to eq(@state)
+      expect(new_address.zip).to eq(@zip)
+    end
+
+    it "if nickname field is left blank, it defaults to home" do
+      visit edit_user_address_path(@addr_1)
+
+      # DON'T fill_in "address[nickname]"
+      fill_in "address[street]", with: @street
+      fill_in "address[city]", with: @city
+      fill_in "address[state]", with: @state
+      fill_in "address[zip]", with: @zip
+
+      click_on "Update Address"
+
+      expect(page).to have_content("Updated \"home\" address")
+      expect(new_address.nickname).to eq("home")
+      expect(new_address.street).to eq(@street)
+      expect(new_address.city).to eq(@city)
+      expect(new_address.state).to eq(@state)
+      expect(new_address.zip).to eq(@zip)
+    end
+
+    it "street input is required" do
+      visit edit_user_address_path(@addr_1)
+
+      fill_in "address[nickname]", with: @nickname
+      # DON'T fill_in "address[street]", with: @street
+      fill_in "address[city]", with: @city
+      fill_in "address[state]", with: @state
+      fill_in "address[zip]", with: @zip
+
+      click_on "Update Address"
+
+      expect(page).to have_field("address[nickname]")
+      expect(page).to have_content("Street can't be blank")
+    end
+
+    it "city input is required" do
+      visit edit_user_address_path(@addr_1)
+
+      fill_in "address[nickname]", with: @nickname
+      fill_in "address[street]", with: @street
+      # DON'T fill_in "address[city]", with: @city
+      fill_in "address[state]", with: @state
+      fill_in "address[zip]", with: @zip
+
+      click_on "Update Address"
+
+      expect(page).to have_field("address[nickname]")
+      expect(page).to have_content("City can't be blank")
+    end
+
+    it "state input is required" do
+      visit edit_user_address_path(@addr_1)
+
+      fill_in "address[nickname]", with: @nickname
+      fill_in "address[street]", with: @street
+      fill_in "address[city]", with: @city
+      # DON'T fill_in "address[state]", with: @state
+      fill_in "address[zip]", with: @zip
+
+      click_on "Update Address"
+
+      expect(page).to have_field("address[nickname]")
+      expect(page).to have_content("State can't be blank")
+    end
+
+    it "zip input is required" do
+      visit edit_user_address_path(@addr_1)
+
+      fill_in "address[nickname]", with: @nickname
+      fill_in "address[street]", with: @street
+      fill_in "address[city]", with: @city
+      fill_in "address[state]", with: @state
+      # DON'T fill_in "address[zip]", with: @zip
+
+      click_on "Update Address"
+
+      expect(page).to have_field("address[nickname]")
+      expect(page).to have_content("Zip can't be blank")
+    end
+  end
+end

--- a/spec/features/user/addresses/edit_spec.rb
+++ b/spec/features/user/addresses/edit_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Editing an existing address" do
     before(:each) do
       @user_1 = create(:user)
       @addr_1 = create(:address, user: @user_1)
-      # @addr_2 = create(:address, user: @user_1)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
 
       @nickname = "my work"
@@ -119,6 +118,26 @@ RSpec.describe "Editing an existing address" do
 
       expect(page).to have_field("address[nickname]")
       expect(page).to have_content("Zip can't be blank")
+    end
+
+    it "I cannot update another user's address" do
+      visit edit_user_address_path(@addr_1)
+
+      @addr_1.update(user: create(:user))
+
+      fill_in "address[nickname]", with: @nickname
+      click_on "Update Address"
+
+      expect(status_code).to eq(404)
+      expect(@addr_1.reload.nickname).to_not eq(@nickname)
+    end
+
+    xit "there is no button on my profile page to edit addresses associated with completed orders" do
+
+    end
+
+    xit "I cannot edit an address associated with a completed order" do
+
     end
   end
 end

--- a/spec/features/user/addresses/edit_spec.rb
+++ b/spec/features/user/addresses/edit_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Editing an existing address" do
     before(:each) do
       @user_1 = create(:user)
       @addr_1 = create(:address, user: @user_1)
-      @addr_2 = create(:address, user: @user_1)
+      # @addr_2 = create(:address, user: @user_1)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
 
       @nickname = "my work"
@@ -38,18 +38,18 @@ RSpec.describe "Editing an existing address" do
 
       expect(current_path).to eq(profile_path)
 
-      expect(page).to have_content("Updated \"#{nickname}\" address")
-      expect(new_address.nickname).to eq(@nickname)
-      expect(new_address.street).to eq(@street)
-      expect(new_address.city).to eq(@city)
-      expect(new_address.state).to eq(@state)
-      expect(new_address.zip).to eq(@zip)
+      expect(page).to have_content("Updated \"#{@nickname}\" address")
+      expect(@addr_1.reload.nickname).to eq(@nickname)
+      expect(@addr_1.reload.street).to eq(@street)
+      expect(@addr_1.reload.city).to eq(@city)
+      expect(@addr_1.reload.state).to eq(@state)
+      expect(@addr_1.reload.zip).to eq(@zip)
     end
 
-    it "if nickname field is left blank, it defaults to home" do
+    it "nickname input is required" do
       visit edit_user_address_path(@addr_1)
 
-      # DON'T fill_in "address[nickname]"
+      fill_in "address[nickname]", with: ""
       fill_in "address[street]", with: @street
       fill_in "address[city]", with: @city
       fill_in "address[state]", with: @state
@@ -57,19 +57,15 @@ RSpec.describe "Editing an existing address" do
 
       click_on "Update Address"
 
-      expect(page).to have_content("Updated \"home\" address")
-      expect(new_address.nickname).to eq("home")
-      expect(new_address.street).to eq(@street)
-      expect(new_address.city).to eq(@city)
-      expect(new_address.state).to eq(@state)
-      expect(new_address.zip).to eq(@zip)
+      expect(page).to have_field("address[nickname]")
+      expect(page).to have_content("Nickname can't be blank")
     end
 
     it "street input is required" do
       visit edit_user_address_path(@addr_1)
 
       fill_in "address[nickname]", with: @nickname
-      # DON'T fill_in "address[street]", with: @street
+      fill_in "address[street]", with: ""
       fill_in "address[city]", with: @city
       fill_in "address[state]", with: @state
       fill_in "address[zip]", with: @zip
@@ -85,7 +81,7 @@ RSpec.describe "Editing an existing address" do
 
       fill_in "address[nickname]", with: @nickname
       fill_in "address[street]", with: @street
-      # DON'T fill_in "address[city]", with: @city
+      fill_in "address[city]", with: ""
       fill_in "address[state]", with: @state
       fill_in "address[zip]", with: @zip
 
@@ -101,7 +97,7 @@ RSpec.describe "Editing an existing address" do
       fill_in "address[nickname]", with: @nickname
       fill_in "address[street]", with: @street
       fill_in "address[city]", with: @city
-      # DON'T fill_in "address[state]", with: @state
+      fill_in "address[state]", with: ""
       fill_in "address[zip]", with: @zip
 
       click_on "Update Address"
@@ -117,7 +113,7 @@ RSpec.describe "Editing an existing address" do
       fill_in "address[street]", with: @street
       fill_in "address[city]", with: @city
       fill_in "address[state]", with: @state
-      # DON'T fill_in "address[zip]", with: @zip
+      fill_in "address[zip]", with: ""
 
       click_on "Update Address"
 

--- a/spec/features/user/addresses/edit_spec.rb
+++ b/spec/features/user/addresses/edit_spec.rb
@@ -120,6 +120,14 @@ RSpec.describe "Editing an existing address" do
       expect(page).to have_content("Zip can't be blank")
     end
 
+    it "I cannot see the form to update another user's address" do
+      @addr_1.update(user: create(:user))
+
+      visit edit_user_address_path(@addr_1)
+
+      expect(status_code).to eq(404)
+    end
+
     it "I cannot update another user's address" do
       visit edit_user_address_path(@addr_1)
 

--- a/spec/features/user/addresses/edit_spec.rb
+++ b/spec/features/user/addresses/edit_spec.rb
@@ -140,8 +140,36 @@ RSpec.describe "Editing an existing address" do
       expect(@addr_1.reload.nickname).to_not eq(@nickname)
     end
 
-    xit "there is no button on my profile page to edit addresses associated with completed orders" do
+    it "there is no button on my profile page to edit addresses associated with completed orders" do
+      addr_2 = create(:address, user: @user_1)
+      pending_order = create(:order, address: addr_2, user: @user_1)
 
+      addr_3 = create(:address, user: @user_1)
+      packaged_order = create(:packaged_order, address: addr_3, user: @user_1)
+
+      addr_4 = create(:address, user: @user_1)
+      shipped_order = create(:shipped_order, address: addr_4, user: @user_1)
+
+      addr_5 = create(:address, user: @user_1)
+      cancelled_order = create(:cancelled_order, address: addr_5, user: @user_1)
+
+      visit profile_path
+
+      within("#address-#{addr_2.id}") do
+        expect(page).to have_link("Edit Address")
+      end
+
+      within("#address-#{addr_3.id}") do
+        expect(page).to_not have_link("Edit Address")
+      end
+
+      within("#address-#{addr_4.id}") do
+        expect(page).to_not have_link("Edit Address")
+      end
+
+      within("#address-#{addr_5.id}") do
+        expect(page).to have_link("Edit Address")
+      end
     end
 
     xit "I cannot edit an address associated with a completed order" do

--- a/spec/features/user/orders/show_spec.rb
+++ b/spec/features/user/orders/show_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "User Profile Order Show Page", type: :feature do
       find('#order_address_id').select(@another_address.street)
       click_button 'Change Shipping Address'
 
-      expect(page).to have_content("Shipping address can only be changed for pending orders")
+      expect(page).to have_content("Shipping address cannot be changed for completed orders")
       expect(page).to have_content(@address.nickname.titlecase)
       expect(page).to have_content(@address.street)
     end
@@ -105,12 +105,12 @@ RSpec.describe "User Profile Order Show Page", type: :feature do
       find('#order_address_id').select(@another_address.street)
       click_button 'Change Shipping Address'
 
-      expect(page).to have_content("Shipping address can only be changed for pending orders")
+      expect(page).to have_content("Shipping address cannot be changed for completed orders")
       expect(page).to have_content(@address.nickname.titlecase)
       expect(page).to have_content(@address.street)
     end
 
-    it "does not allow me to change the address for a cancelled order" do
+    it "does allow me to change the address for a cancelled order" do
       visit user_order_path(@order)
 
       @order.update(status: "cancelled")
@@ -118,9 +118,9 @@ RSpec.describe "User Profile Order Show Page", type: :feature do
       find('#order_address_id').select(@another_address.street)
       click_button 'Change Shipping Address'
 
-      expect(page).to have_content("Shipping address can only be changed for pending orders")
-      expect(page).to have_content(@address.nickname.titlecase)
-      expect(page).to have_content(@address.street)
+      expect(page).to_not have_content("Shipping address cannot be changed for completed orders")
+      expect(page).to have_content(@another_address.nickname.titlecase)
+      expect(page).to have_content(@another_address.street)
     end
 
     it "does not allow me to change the address for a different user's pending order" do

--- a/spec/features/user/users/edit_spec.rb
+++ b/spec/features/user/users/edit_spec.rb
@@ -6,13 +6,7 @@ RSpec.describe "profile edit page" do
       @email = "abc@def.com"
       @password = "pw123"
       @name = "Abc Def"
-      @street = "123 Abc St"
-      @city = "New York City"
-      @state = "NY"
-      @zip = "12345"
       @user = User.create!(email: @email, password: @password, name: @name)
-      @address = Address.create!(street: @street, city: @city, state: @state, zip: @zip, user: @user)
-      @user.update!(primary_address: @address)
 
       visit login_path
 
@@ -30,10 +24,6 @@ RSpec.describe "profile edit page" do
       expect(page).to have_field("user[email]")
       expect(page).to have_field("user[password]")
       expect(page).to have_field("user[password_confirmation]")
-      expect(page).to have_field("user[addresses_attributes][0][street]")
-      expect(page).to have_field("user[addresses_attributes][0][city]")
-      expect(page).to have_field("user[addresses_attributes][0][state]")
-      expect(page).to have_field("user[addresses_attributes][0][zip]")
 
       click_button "Submit Changes"
 
@@ -41,9 +31,6 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(@user.name)
       expect(page).to have_content(@user.email)
-      expect(page).to have_content(@address.street)
-      expect(page).to have_content("#{@address.city}, #{@address.state}")
-      expect(page).to have_content(@address.zip)
     end
 
     it "I can edit my name" do
@@ -57,63 +44,6 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_name)
       expect(page).to_not have_content(@name)
-    end
-
-    it "I can edit my address" do
-      visit profile_edit_path
-
-      new_address = "7264 Blah St"
-
-      fill_in "user[addresses_attributes][0][street]", with: new_address
-      click_button "Submit Changes"
-
-      expect(page).to have_content("Your profile has been updated")
-      expect(page).to have_content(new_address)
-      expect(page).to_not have_content(@street)
-    end
-
-    it "I can edit my city" do
-      visit profile_edit_path
-
-      new_city = "New Orleans"
-
-      fill_in "user[addresses_attributes][0][city]", with: new_city
-      click_button "Submit Changes"
-
-      expect(page).to have_content("Your profile has been updated")
-      expect(page).to have_content(new_city)
-      expect(page).to_not have_content(@city)
-    end
-
-    it "I can edit my state" do
-      visit profile_edit_path
-
-      new_state = "LA"
-
-      fill_in "user[addresses_attributes][0][state]", with: new_state
-      click_button "Submit Changes"
-
-      expect(page).to have_content("Your profile has been updated")
-      expect(page).to have_content(new_state)
-      expect(page).to_not have_content(@state)
-    end
-
-    it "I can edit my zip (and my password is unchanged)" do
-      visit profile_edit_path
-
-      new_zip = "83649"
-      original_pw_digest = @user.password_digest
-
-      fill_in "user[addresses_attributes][0][zip]", with: new_zip
-      click_button "Submit Changes"
-
-      expect(page).to have_content(new_zip)
-      expect(page).to_not have_content(@zip)
-
-      expect(page).to have_content("Your profile has been updated")
-      @user.reload
-      expect(@user.addresses[0].zip).to eq(new_zip)
-      expect(@user.password_digest).to eq(original_pw_digest)
     end
 
     it "I can change my email to an unused email address" do

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -103,10 +103,11 @@ RSpec.describe "profile page" do
     end
 
     it "I can't delete an address with associated packaged orders" do
-      order = create(:packaged_order, address: @address)
       original_addr_id = @address.id
 
       visit profile_path
+
+      order = create(:packaged_order, address: @address)
 
       within("#address-#{@address.id}") do
         click_button "Delete Address"
@@ -118,10 +119,11 @@ RSpec.describe "profile page" do
     end
 
     it "I can't delete an address with associated shipped orders" do
-      order = create(:shipped_order, address: @address)
       original_addr_id = @address.id
 
       visit profile_path
+      
+      order = create(:shipped_order, address: @address)
 
       within("#address-#{@address.id}") do
         click_button "Delete Address"


### PR DESCRIPTION
This PR/branch...
 - Separates out the editing of addresses from the user profile edit page -- new form for a specific address
 - Restricts users from updating addresses associated with other users, or shipped/packaged orders
 - Allows a user to change which address is associated with a pending order
 - Removes buttons to edit/delete an address if that address is associated with a completed order