### PR TITLE
Cleanup

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -58,7 +58,7 @@ class Item < ApplicationRecord
 
   def sufficient_inventory?(order)
     item_quantity = order_items.where("order_items.order_id=?", order.id).first.quantity
-    inventory > item_quantity
+    inventory >= item_quantity
   end
 
   def bulk_price(quantity)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
                         :role
   has_many :orders
   has_many :items
-  has_many :bulk_discounts
+  has_many :bulk_discounts, dependent: :destroy
   has_one :primary_address, class_name: 'Address'
 
   has_many :addresses, dependent: :destroy

--- a/app/views/user/orders/show.html.erb
+++ b/app/views/user/orders/show.html.erb
@@ -11,20 +11,24 @@
   <p><%= @address.street %></p>
   <p><%= @address.city %>, <%= @address.state %></p>
   <p><%= @address.zip %></p>
-  <h6>or change address...</h6>
+  <% if @order.status == "pending" %>
+    <h6>or change address...</h6>
+  <% end %>
 <% else %>
   <h5>No address associated with this order. Select one below:</h5>
 <% end %>
-<%= form_tag(user_order_path(@order), method: "patch") do %>
-  <%= collection_select(
-    :order,
-    :address_id,
-    @addresses,
-    :id,
-    :street,
-    { selected: current_user.primary_address_id }
-  ) %>
-  <%= submit_tag("Change Shipping Address", class: "btn btn-primary") %>
+<% if @order.status == "pending" %>
+  <%= form_tag(user_order_path(@order), method: "patch") do %>
+    <%= collection_select(
+      :order,
+      :address_id,
+      @addresses,
+      :id,
+      :street,
+      { selected: current_user.primary_address_id }
+    ) %>
+    <%= submit_tag("Change Shipping Address", class: "btn btn-primary") %>
+  <% end %>
 <% end %>
 <br>
 <h5>Items Ordered:</h5>

--- a/spec/features/user/orders/show_spec.rb
+++ b/spec/features/user/orders/show_spec.rb
@@ -84,6 +84,24 @@ RSpec.describe "User Profile Order Show Page", type: :feature do
       expect(page).to have_content(@another_address.zip)
     end
 
+    it "does not show a dropdown/button to change the address for a packaged order" do
+      @order.update(status: "packaged")
+      visit user_order_path(@order)
+      expect(page).to_not have_button "Change Shipping Address"
+    end
+
+    it "does not show a dropdown/button to change the address for a shipped order" do
+      @order.update(status: "shipped")
+      visit user_order_path(@order)
+      expect(page).to_not have_button "Change Shipping Address"
+    end
+
+    it "does not show a dropdown/button to change the address for a cancelled order" do
+      @order.update(status: "cancelled")
+      visit user_order_path(@order)
+      expect(page).to_not have_button "Change Shipping Address"
+    end
+
     it "does not allow me to change the address for a packaged order" do
       visit user_order_path(@order)
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Item, type: :model do
       user = create(:user)
       order_1 = create(:order, user: user)
       order_4 = create(:order, user: user)
+      order_5 = create(:order, user: user)
 
       user_2 = create(:user)
       order_2 = create(:order, user: user_2)
@@ -172,6 +173,9 @@ RSpec.describe Item, type: :model do
       #order 4 with only other merchant's items.
       oi_8 = create(:order_item, item: item_1, order: order_4, quantity: 5, price_per_item: item_1.price)
 
+      #order 5 with pending status for current merchant's item, inventory equal to quantity
+      oi_9 = create(:order_item, item: item_2, order: order_5, quantity: 10, price_per_item: item_1.price)
+
       expect(item_3.item_fulfilled?(order_2)).to eq(true)
       expect(item_2.item_fulfilled?(order_2)).to eq(false)
       expect(item_2.item_fulfilled?(order_1)).to eq(false)
@@ -179,6 +183,7 @@ RSpec.describe Item, type: :model do
       expect(item_4.sufficient_inventory?(order_2)).to eq(false)
       expect(item_2.sufficient_inventory?(order_2)).to eq(true)
       expect(item_2.sufficient_inventory?(order_1)).to eq(true)
+      expect(item_2.sufficient_inventory?(order_5)).to eq(true)
     end
 
     it "#item_orders returns order_item objects for a specific item in an order" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe User, type: :model do
     it {should have_many :addresses}
     it {should have_many :bulk_discounts}
     it {should have_one :primary_address}
+
+    it "destroying a merchant destroys its bulk discounts" do
+      merchant = create(:merchant)
+      bulk_discount = create(:bulk_discount, user: merchant)
+
+      merchant.destroy
+
+      expect(User.count).to eq(0)
+      expect(BulkDiscount.count).to eq(0)
+    end
   end
 
   describe 'Class Methods' do


### PR DESCRIPTION
 - Fix bug in `Item#sufficient_inventory?`. Was comparing inventory to order quantity using `>` instead of `>=`.
 - Hide dropdown/button for the user to change the address on the order show page (for all but pending orders)
 - Automatically destroy bulk_discounts associated with a merchant when the merchant is destroyed